### PR TITLE
Refactor and start unit tests for websocket server

### DIFF
--- a/app.go
+++ b/app.go
@@ -219,20 +219,13 @@ func (a *App) onCreateSessionMsg(senderClient Client, msg CreateSessionMsg) {
 		ClientIDs:   []string{},
 		createdDate: time.Now(),
 	}
-	clientIDsToAdd := []string{senderClient.ID}
-	if _, ok := a.ClientMap[msg.AddClientID]; ok {
-		clientIDsToAdd = append(clientIDsToAdd, msg.AddClientID)
+	// Add client who created session to session
+	AddClientToSessionMsg := AddClientToSessionMsg{
+		Type:        "AddClientToSession",
+		SessionID:   session.ID,
+		AddClientID: senderClient.ID,
 	}
-	a.SessionMap[session.ID] = session
-	fmt.Println("Created session", session)
-	for _, clientID := range clientIDsToAdd {
-		AddClientToSessionMsg := AddClientToSessionMsg{
-			Type:        "AddClientToSession",
-			SessionID:   session.ID,
-			AddClientID: clientID,
-		}
-		a.onAddClientToSessionMsg(senderClient, AddClientToSessionMsg, false)
-	}
+	a.onAddClientToSessionMsg(senderClient, AddClientToSessionMsg, false)
 }
 
 func (a *App) onAddClientToSessionMsg(senderClient Client, msg AddClientToSessionMsg, replyToSender bool) {

--- a/app.go
+++ b/app.go
@@ -41,8 +41,6 @@ func (a *App) Init() {
 	// @TODO Secure with an admin password
 	a.Router.HandleFunc("/api/v1/clients", a.getClients)
 	a.Router.HandleFunc("/api/v1/sessions", a.getSessions)
-
-	log.Fatal(a.ListenOnPort(4010, false))
 }
 
 func (a *App) newClientId() int {
@@ -95,13 +93,17 @@ func (a *App) getSessionClientMap(sessionID string) map[string]Client {
 	return map[string]Client{}
 }
 
+func (a *App) MainHandler() http.Handler {
+	return handlers.CORS()(a.Router)
+}
+
 // ListenOnPort Starts the app listening on the provided port
 func (a *App) ListenOnPort(port int, useSSL bool) error {
 	fmt.Println("Starting server on port ", port, " use ssl ", useSSL)
 	if useSSL {
-		return http.ListenAndServeTLS(fmt.Sprint(":", port), "ssl/server.crt", "ssl/server.key", handlers.CORS()(a.Router))
+		return http.ListenAndServeTLS(fmt.Sprint(":", port), "ssl/server.crt", "ssl/server.key", a.MainHandler())
 	}
-	return http.ListenAndServe(fmt.Sprint(":", port), handlers.CORS()(a.Router))
+	return http.ListenAndServe(fmt.Sprint(":", port), a.MainHandler())
 }
 
 func (a *App) serveWs(w http.ResponseWriter, r *http.Request) {

--- a/app.go
+++ b/app.go
@@ -221,6 +221,7 @@ func (a *App) onCreateSessionMsg(senderClient Client, msg CreateSessionMsg) {
 		ClientIDs:   []string{},
 		createdDate: time.Now(),
 	}
+	a.SessionMap[session.ID] = session
 	// Add client who created session to session
 	AddClientToSessionMsg := AddClientToSessionMsg{
 		Type:        "AddClientToSession",

--- a/app_test.go
+++ b/app_test.go
@@ -301,6 +301,113 @@ func Test_two_clients_can_join_session(t *testing.T) {
 
 	sessionId := client1AddedToSessionMsg.SessionID
 
+	t.Logf("Client 1 created and added itself to session with id %s", sessionId)
+
+	addClient2ToSessionMsg := AddClientToSessionMsg{
+		Type:        "AddClientToSession",
+		SessionID:   sessionId,
+		AddClientID: client2ConnectMsg.Client.ID,
+	}
+	err = ws.WriteJSON(addClient2ToSessionMsg)
+	if err != nil {
+		t.Fatal("Failed to send AddClientToSessionMsg for client 2")
+	}
+
+	// Client 2 should receive a message that it was added to the new session
+	_, msgBytes, _ = ws2.ReadMessage()
+	msgString = string(msgBytes)
+	log.Printf("msg string %s", msgString)
+	var client2AddedToSessionMsg ClientJoinedSessionMsg
+	err = json.Unmarshal(msgBytes, &client2AddedToSessionMsg)
+	if err != nil {
+		t.Fatalf("Error parsing ClientJoinedSessionMsg")
+	}
+	if client2AddedToSessionMsg.SessionID != sessionId {
+		t.Fatalf("Expected client 2 to be added to session with id %s but was %s", sessionId, client2AddedToSessionMsg.SessionID)
+	}
+}
+
+// Example payload for session broadcasts
+type ExamplePayload struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+func Test_session_owner_can_broadcast_to_another_client(t *testing.T) {
+	testServer, wsUrl := SetupWsServer(t)
+	defer testServer.Close()
+
+	// Client 1 connect
+	ws, _, err := websocket.DefaultDialer.Dial(wsUrl, nil)
+	if err != nil {
+		t.Fatalf("Failed to connect to websocket server: %v", err)
+	}
+	defer CloseWithCloseMessage(ws)
+
+	// Received client 1 connect message
+	_, msgBytes, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Parse client 1 connect message json
+	var client1ConnectMsg ClientConnectMsg
+	err = json.Unmarshal(msgBytes, &client1ConnectMsg)
+	if err != nil {
+		t.Fatalf("Error parsing client1 message json as ClientConnectMsg: %v", err)
+	}
+
+	// Client 2 connect
+	ws2, _, err := websocket.DefaultDialer.Dial(wsUrl, nil)
+	if err != nil {
+		t.Fatalf("Failed to connect client 1 to websocket server: %v", err)
+	}
+	defer CloseWithCloseMessage(ws)
+
+	// Received client 2 connect message
+	_, msgBytes, err = ws2.ReadMessage()
+	if err != nil {
+		t.Fatalf("Failed to connect client 2 to websocket server: %v", err)
+	}
+
+	// Parse client 2 connect message json
+	var client2ConnectMsg ClientConnectMsg
+	err = json.Unmarshal(msgBytes, &client2ConnectMsg)
+	if err != nil {
+		t.Fatalf("Error parsing client2 message json as ClientConnectMsg: %v", err)
+	}
+
+	if client1ConnectMsg.Client.ID == client2ConnectMsg.Client.ID {
+		t.Fatalf("Expected clients to each have unique id but both were %s", client2ConnectMsg.Client.ID)
+	}
+
+	// Client 1 creates session
+	createSessionMsg := CreateSessionMsg{
+		Type: "CreateSession",
+	}
+	err = ws.WriteJSON(createSessionMsg)
+	if err != nil {
+		t.Fatalf("Failed to send CreateSessionMsg %v", err)
+	}
+
+	// Client 1 should receive a message that it was added to the new session
+	_, msgBytes, _ = ws.ReadMessage()
+	msgString := string(msgBytes)
+	log.Printf("msg string %s", msgString)
+	var client1AddedToSessionMsg ClientJoinedSessionMsg
+	err = json.Unmarshal(msgBytes, &client1AddedToSessionMsg)
+	if err != nil {
+		t.Fatalf("Error parsing ClientJoinedSessionMsg")
+	}
+	if client1AddedToSessionMsg.SessionOwnerID != client1ConnectMsg.Client.ID {
+		t.Fatalf(
+			"Expected session owner client to be first client that connected with id %s",
+			client1ConnectMsg.Client.ID,
+		)
+	}
+
+	sessionId := client1AddedToSessionMsg.SessionID
+
 	t.Log("Client 1 created and added itself to session with id ")
 
 	addClient2ToSessionMsg := AddClientToSessionMsg{
@@ -325,4 +432,33 @@ func Test_two_clients_can_join_session(t *testing.T) {
 	if client2AddedToSessionMsg.SessionID != sessionId {
 		t.Fatalf("Expected client 2 to be added to session with id %s but was %s", sessionId, client2AddedToSessionMsg.SessionID)
 	}
+
+	// Client 1 (session owner) broadcast to other clients in session
+	payload := ExamplePayload{
+		Title: "test title",
+		Body:  "test body",
+	}
+	broadcastToSessionMsg := BroadcastToSessionMsg{
+		Type:    "BroadcastToSessionMsg",
+		Payload: payload,
+	}
+	err = ws.WriteJSON(broadcastToSessionMsg)
+	if err != nil {
+		t.Fatalf("Failed to write JSON for broadcast message from client 1 to session %v", err)
+	}
+
+	// Expect client 2 to receive broadcast
+	_, msgBytes, _ = ws2.ReadMessage()
+	msgString = string(msgBytes)
+	log.Printf("msg string %s", msgString)
+	var broadcastFromSessionMsg BroadcastFromSessionMsg
+	err = json.Unmarshal(msgBytes, &broadcastFromSessionMsg)
+	if err != nil {
+		t.Fatalf("Error parsing BroadcastFromSessionMsg")
+	}
+
+	if broadcastFromSessionMsg.Payload != payload {
+		t.Fatalf("Expected payload received to be same as one sent received %v", broadcastFromSessionMsg.Payload)
+	}
+
 }

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestServerStarts(t *testing.T) {
+	app := App{}
+	app.Init()
+	testServer := httptest.NewServer(app.MainHandler())
+	defer testServer.Close()
+
+	// Connect to the server
+	clientsUrl := fmt.Sprintf("%s%s", testServer.URL, "")
+	_, err := http.Get(clientsUrl)
+	if err != nil {
+		t.Fail()
+	}
+}
+
+func TestServerStarts2(t *testing.T) {
+	app := App{}
+	app.Init()
+	testServer := httptest.NewServer(app.MainHandler())
+	defer testServer.Close()
+
+	// Convert http://127.0.0.1 to ws://127.0.0.
+	u := "ws" + strings.TrimPrefix(testServer.URL, "http")
+
+	// Connect to the server
+	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer ws.Close()
+
+	// Send message to server, read response and check to see if it's what we expect.
+	for i := 0; i < 10; i++ {
+		if err := ws.WriteMessage(websocket.TextMessage, []byte("hello")); err != nil {
+			t.Fatalf("%v", err)
+		}
+		_, p, err := ws.ReadMessage()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		if string(p) != "hello" {
+			t.Fatalf("bad message")
+		}
+	}
+}

--- a/app_test.go
+++ b/app_test.go
@@ -27,40 +27,43 @@ func TestServerStarts(t *testing.T) {
 	log.Printf("%s", clientsUrl)
 }
 
-func SetupServerAndConnect(t *testing.T) (*websocket.Conn, *httptest.Server) {
+func SetupWsServer(t *testing.T) (*httptest.Server, string) {
 	app := App{}
 	app.Init()
 	testServer := httptest.NewServer(app.MainHandler())
 
 	// Convert http://127.0.0.1 to ws://127.0.0/api/v1/ws
-	u := "ws" + strings.TrimPrefix(testServer.URL, "http") + "/api/v1/ws"
+	wsUrl := "ws" + strings.TrimPrefix(testServer.URL, "http") + "/api/v1/ws"
 
-	log.Printf("Url %s", u)
-
-	// Connect to the server
-	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	return ws, testServer
+	return testServer, wsUrl
 }
 
 func TestServerStartsAndWebsocketCanConnect(t *testing.T) {
-	ws, testServer := SetupServerAndConnect(t)
-	defer ws.Close()
+	testServer, wsUrl := SetupWsServer(t)
 	defer testServer.Close()
 
+	ws, _, err := websocket.DefaultDialer.Dial(wsUrl, nil)
+	if err != nil {
+		t.Fatalf("Failed to connect to websocket server: %v", err)
+	}
+	defer ws.Close()
+
 	// Send message to server, read response and check to see if it's what we expect.
-	_, _, err := ws.ReadMessage()
+	_, _, err = ws.ReadMessage()
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
 }
 
 func TestFirstMessageIsClientConnect(t *testing.T) {
-	ws, testServer := SetupServerAndConnect(t)
-	defer ws.Close()
+	testServer, wsUrl := SetupWsServer(t)
 	defer testServer.Close()
+
+	ws, _, err := websocket.DefaultDialer.Dial(wsUrl, nil)
+	if err != nil {
+		t.Fatalf("Failed to connect to websocket server: %v", err)
+	}
+	defer ws.Close()
 
 	_, msgBytes, err := ws.ReadMessage()
 	if err != nil {
@@ -71,5 +74,72 @@ func TestFirstMessageIsClientConnect(t *testing.T) {
 	json.Unmarshal(msgBytes, &connectMsgJson)
 	if connectMsgJson["type"] != "ClientConnect" {
 		t.Fatalf("Expected type to be ClientConnect but was %s", connectMsgJson["type"])
+	}
+}
+
+func TestFirstMessageHasClient(t *testing.T) {
+	testServer, wsUrl := SetupWsServer(t)
+	defer testServer.Close()
+
+	ws, _, err := websocket.DefaultDialer.Dial(wsUrl, nil)
+	if err != nil {
+		t.Fatalf("Failed to connect to websocket server: %v", err)
+	}
+	defer ws.Close()
+
+	_, msgBytes, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	var clientConnectMsg ClientConnectMsg
+	err = json.Unmarshal(msgBytes, &clientConnectMsg)
+	if err != nil {
+		t.Fatalf("Error parsing message json as ClientConnectMsg: %v", err)
+	}
+}
+
+func TestTwoClientsCanConnectAndHaveDifferentIds(t *testing.T) {
+	testServer, wsUrl := SetupWsServer(t)
+	defer testServer.Close()
+
+	// Client 1 connect
+	ws, _, err := websocket.DefaultDialer.Dial(wsUrl, nil)
+	if err != nil {
+		t.Fatalf("Failed to connect to websocket server: %v", err)
+	}
+	defer ws.Close()
+
+	_, msgBytes, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	var client1ConnectMsg ClientConnectMsg
+	err = json.Unmarshal(msgBytes, &client1ConnectMsg)
+	if err != nil {
+		t.Fatalf("Error parsing client1 message json as ClientConnectMsg: %v", err)
+	}
+
+	// Client 2 connect
+	ws2, _, err := websocket.DefaultDialer.Dial(wsUrl, nil)
+	if err != nil {
+		t.Fatalf("Failed to connect client 1 to websocket server: %v", err)
+	}
+	defer ws2.Close()
+
+	_, msgBytes, err = ws2.ReadMessage()
+	if err != nil {
+		t.Fatalf("Failed to connect client 2 to websocket server: %v", err)
+	}
+
+	var client2ConnectMsg ClientConnectMsg
+	err = json.Unmarshal(msgBytes, &client2ConnectMsg)
+	if err != nil {
+		t.Fatalf("Error parsing client2 message json as ClientConnectMsg: %v", err)
+	}
+
+	if client1ConnectMsg.Client.ID == client2ConnectMsg.Client.ID {
+		t.Fatalf("Expected clients to each have unique id but both were %s", client2ConnectMsg.Client.ID)
 	}
 }

--- a/app_test.go
+++ b/app_test.go
@@ -434,13 +434,13 @@ func Test_session_owner_can_broadcast_to_another_client(t *testing.T) {
 	}
 
 	// Client 1 (session owner) broadcast to other clients in session
-	payload := ExamplePayload{
+	sentPayload := ExamplePayload{
 		Title: "test title",
 		Body:  "test body",
 	}
 	broadcastToSessionMsg := BroadcastToSessionMsg{
 		Type:    "BroadcastToSession",
-		Payload: payload,
+		Payload: sentPayload,
 	}
 	err = ws.WriteJSON(broadcastToSessionMsg)
 	if err != nil {
@@ -457,8 +457,17 @@ func Test_session_owner_can_broadcast_to_another_client(t *testing.T) {
 		t.Fatalf("Error parsing BroadcastFromSessionMsg")
 	}
 
-	if broadcastFromSessionMsg.Payload != payload {
-		t.Fatalf("Expected payload received to be same as one sent received %v", broadcastFromSessionMsg.Payload)
+	receivedPayload := broadcastFromSessionMsg.Payload.(map[string]interface{})
+
+	if receivedPayload["Body"] != sentPayload.Body {
+		t.Logf("Received payload: %v", broadcastFromSessionMsg.Payload)
+		t.Logf("Sent payload: %v", sentPayload)
+		t.Fatalf(
+			"Expected payload body received to be same as one sent but sent %s is different from received %s",
+			sentPayload.Body,
+			receivedPayload["Body"],
+		)
+
 	}
 
 }

--- a/app_test.go
+++ b/app_test.go
@@ -439,7 +439,7 @@ func Test_session_owner_can_broadcast_to_another_client(t *testing.T) {
 		Body:  "test body",
 	}
 	broadcastToSessionMsg := BroadcastToSessionMsg{
-		Type:    "BroadcastToSessionMsg",
+		Type:    "BroadcastToSession",
 		Payload: payload,
 	}
 	err = ws.WriteJSON(broadcastToSessionMsg)

--- a/app_test.go
+++ b/app_test.go
@@ -434,10 +434,7 @@ func Test_session_owner_can_broadcast_to_another_client(t *testing.T) {
 	}
 
 	// Client 1 (session owner) broadcast to other clients in session
-	sentPayload := ExamplePayload{
-		Title: "test title",
-		Body:  "test body",
-	}
+	sentPayload := "{\"test\":\"testy\"}"
 	broadcastToSessionMsg := BroadcastToSessionMsg{
 		Type:    "BroadcastToSession",
 		Payload: sentPayload,
@@ -457,17 +454,16 @@ func Test_session_owner_can_broadcast_to_another_client(t *testing.T) {
 		t.Fatalf("Error parsing BroadcastFromSessionMsg")
 	}
 
-	receivedPayload := broadcastFromSessionMsg.Payload.(map[string]interface{})
+	receivedPayload := broadcastFromSessionMsg.Payload
 
-	if receivedPayload["Body"] != sentPayload.Body {
+	if sentPayload != receivedPayload {
 		t.Logf("Received payload: %v", broadcastFromSessionMsg.Payload)
 		t.Logf("Sent payload: %v", sentPayload)
 		t.Fatalf(
 			"Expected payload body received to be same as one sent but sent %s is different from received %s",
-			sentPayload.Body,
-			receivedPayload["Body"],
+			sentPayload,
+			receivedPayload,
 		)
-
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
-import "os"
+import (
+	"log"
+	"os"
+)
 
 func main() {
 	if len(os.Args) > 1 && os.Args[1] == "-ts" {
@@ -8,5 +11,6 @@ func main() {
 	} else {
 		app := App{}
 		app.Init()
+		log.Fatal(app.ListenOnPort(4010, false))
 	}
 }

--- a/models.ts
+++ b/models.ts
@@ -4,6 +4,7 @@ export namespace ServerTypes {
     export interface Client {
         id: string;
         name: string;
+        lastJoinTime: string;
     }
     export interface Session {
         id: string;
@@ -16,7 +17,6 @@ export namespace ServerTypes {
     }
     export interface CreateSessionMsg {
         type: "CreateSession";
-        addClientId: string;
     }
     export interface UpdateClientMsg {
         type: "UpdateClient";
@@ -32,24 +32,24 @@ export namespace ServerTypes {
         clientId: string;
         sessionId: string;
         sessionOwnerId: string;
-        clientMap: { [key: string]: Client };
+        clientMap: {[key: string]: Client};
     }
     export interface ClientLeftSessionMsg {
         type: "ClientLeftSession";
         clientId: string;
         sessionId: string;
         sessionOwnerId: string;
-        clientMap: { [key: string]: Client };
+        clientMap: {[key: string]: Client};
     }
     export interface BroadcastToSessionMsg {
         type: "BroadcastToSession";
-        payload: any;
+        payload: string;
     }
     export interface BroadcastFromSessionMsg {
         type: "BroadcastFromSession";
         fromSessionOwner: boolean;
         senderId: string;
-        payload: any;
+        payload: string;
     }
     export interface ErrorMsg {
         type: "Error";

--- a/msg_types.go
+++ b/msg_types.go
@@ -64,8 +64,7 @@ type Session struct {
 
 // CreateSessionMsg - Sent from client to create session
 type CreateSessionMsg struct {
-	Type        string `json:"type"`
-	AddClientID string `json:"addClientId"`
+	Type string `json:"type"`
 }
 
 // ClientConnectMsg - Sent to client on connecting
@@ -105,13 +104,13 @@ type ClientLeftSessionMsg struct {
 	ClientMap      map[string]Client `json:"clientMap"`
 }
 
-// BroadcastToSessionMsg -
+// BroadcastToSessionMsg - Used by client to send content to all clients in session
 type BroadcastToSessionMsg struct {
 	Type    string      `json:"type"`
 	Payload interface{} `json:"payload"`
 }
 
-// BroadcastFromSessionMsg -
+// BroadcastFromSessionMsg - Used by server to send content all clients in a session
 type BroadcastFromSessionMsg struct {
 	Type             string      `json:"type"`
 	FromSessionOwner bool        `json:"fromSessionOwner"`

--- a/msg_types.go
+++ b/msg_types.go
@@ -26,6 +26,9 @@ func convertToTS() {
 		Add(InfoMsg{})
 
 	converter.CreateInterface = true
+	converter.ManageType(time.Time{}, typescriptify.TypeOptions{
+		TSType: "string",
+	})
 	converter.BackupDir = ""
 	tsString, err := converter.Convert(make(map[string]string))
 	if err != nil {

--- a/msg_types.go
+++ b/msg_types.go
@@ -106,16 +106,16 @@ type ClientLeftSessionMsg struct {
 
 // BroadcastToSessionMsg - Used by client to send content to all clients in session
 type BroadcastToSessionMsg struct {
-	Type    string      `json:"type"`
-	Payload interface{} `json:"payload"`
+	Type    string `json:"type"`
+	Payload string `json:"payload"`
 }
 
 // BroadcastFromSessionMsg - Used by server to send content all clients in a session
 type BroadcastFromSessionMsg struct {
-	Type             string      `json:"type"`
-	FromSessionOwner bool        `json:"fromSessionOwner"`
-	SenderID         string      `json:"senderId"`
-	Payload          interface{} `json:"payload"`
+	Type             string `json:"type"`
+	FromSessionOwner bool   `json:"fromSessionOwner"`
+	SenderID         string `json:"senderId"`
+	Payload          string `json:"payload"`
 }
 
 // ErrorMsg - Websocket error message


### PR DESCRIPTION
- Move create client to its own function
- Remove adding of client on session create to simplify
- Start of unit tests for server
- Make payload a string for easier unit tests
